### PR TITLE
Feat : Elastic search nori-tokenizer 적용

### DIFF
--- a/src/main/resources/application-elasticsearch.yaml
+++ b/src/main/resources/application-elasticsearch.yaml
@@ -6,3 +6,5 @@ spring:
       url: ${ELASTIC_SEARCH_URL}
       username: ${ELASTIC_SEARCH_USERNAME}
       password: ${ELASTIC_SEARCH_PASSWORD}
+      index:
+        auto-create: false


### PR DESCRIPTION
- elastic search의 구성을 변경하는 과정이 대부분이라 코드 작성이 적습니다.
1. elastic search에 nori-tokenizer 설치
```
# elasticsearch 설치경로의 bin 에서 진행합니다.
$ bin/elasticsearch-plugin install analysis-nori
```

2. video document의 tokenizer를 nori-tokenizer로 지정
```
PUT /video
{
  "settings": {
    "analysis": {
      "analyzer": {
        "nori_analyzer": {
          "type": "custom",
          "tokenizer": "nori_tokenizer"
        }
      }
    }
  },
  "mappings": {
    "properties": {
      "summary": {
        "type": "text",
        "analyzer": "nori_analyzer"
      }
    }
  }
}

```

3. nginx를 통해 80번 포트 요청(http) -> 8080번 포트(백엔드 포트)로 리다이렉트되게 변경

-참고 : [주소](https://velog.io/@yundleyundle/ElasticSearch-Nori-%ED%98%95%ED%83%9C%EC%86%8C-%EB%B6%84%EC%84%9D%EA%B8%B0-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0)